### PR TITLE
Bugs/mt 5407 increase buffer size

### DIFF
--- a/beanstalk.go
+++ b/beanstalk.go
@@ -28,7 +28,7 @@ type IBeanstalk interface {
 }
 
 type ILentil interface {
-	Dial(addr string, args ...interface{}) (IBeanstalk, error)
+	Dial(addr string, readerSize int, args ...interface{}) (IBeanstalk, error)
 }
 
 type Lentil struct{}

--- a/beanstalk.go
+++ b/beanstalk.go
@@ -1,6 +1,6 @@
 package lentil
 
-//IBeanstalk is an interface to alllow queue DI and mocking.
+// IBeanstalk is an interface to alllow queue DI and mocking.
 type IBeanstalk interface {
 	Watch(tube string) (int, error)
 	Ignore(tube string) (int, error)
@@ -33,8 +33,8 @@ type ILentil interface {
 
 type Lentil struct{}
 
-func (Lentil) Dial(addr string, args ...interface{}) (IBeanstalk, error) {
-	q, err := Dial(addr, args...)
+func (Lentil) Dial(addr string, readerSize int, args ...interface{}) (IBeanstalk, error) {
+	q, err := Dial(addr, readerSize, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/nimblic/lentil
+
+go 1.24.1

--- a/lentil.go
+++ b/lentil.go
@@ -110,7 +110,7 @@ func (this *Beanstalkd) recvdata(data []byte) (int, error) {
 
 // Dial opens a connection to beanstalkd. The format of addr is 'host:port', e.g '0.0.0.0:11300'.
 // Optional arguments can be provided to specify a redialPeriod (Duration) and a retryPeriod (Duration)
-func Dial(addr string, args ...interface{}) (*Beanstalkd, error) {
+func Dial(addr string, readerSize int, args ...interface{}) (*Beanstalkd, error) {
 	redial := time.Duration(0)
 	retry := time.Duration(0)
 	if len(args) == 2 {
@@ -142,7 +142,7 @@ func Dial(addr string, args ...interface{}) (*Beanstalkd, error) {
 	if e != nil {
 		return nil, e
 	}
-	this.reader = bufio.NewReaderSize(this.conn, ReaderSize)
+	this.reader = bufio.NewReaderSize(this.conn, readerSize)
 	return this, nil
 }
 

--- a/lentil_test.go
+++ b/lentil_test.go
@@ -8,11 +8,11 @@ import (
 
 // Test assumes beanstalkd running on 0.0.0.0:11300
 func TestBeanstalk(t *testing.T) {
-	beanstalkd, e := Dial("0.0.0.0:11301")
+	beanstalkd, e := Dial("0.0.0.0:11301", ReaderSize)
 	if beanstalkd != nil || e == nil {
 		t.Error("Shouldn't have connected")
 	}
-	beanstalkd, e = Dial("0.0.0.0:11300")
+	beanstalkd, e = Dial("0.0.0.0:11300", ReaderSize)
 	if beanstalkd == nil || e != nil {
 		t.Fatal("Should have connected without errors. Is beanstalkd running on 0.0.0.0:11300?")
 	}
@@ -183,7 +183,7 @@ func TestBeanstalk(t *testing.T) {
 }
 
 func ExampleBeanstalkd() {
-	queue, e := Dial("0.0.0.0:11300")
+	queue, e := Dial("0.0.0.0:11300", ReaderSize)
 	if e != nil {
 		log.Fatal(e)
 	}


### PR DESCRIPTION
This pull request introduces a new `readerSize` parameter to the `Dial` function across the codebase, enabling more control over the buffer size for connections. It also updates the `go.mod` file to define the module and Go version. Below are the key changes:

### API Changes:
* Updated the `Dial` method in the `ILentil` interface and its implementation to include a `readerSize` parameter, allowing customization of the buffer size for connections. (`beanstalk.go`, `lentil.go`) [[1]](diffhunk://#diff-d1eba74272f39ed2fe6a1edbaeb531bfa52f7d1798c3b986ca1f03ed8d80678bL31-R37) [[2]](diffhunk://#diff-76bb79d5d1a56c3bd6c9d33f5532f17b0b2d0525d0b3e2a92fca3328bca27eeaL113-R113)
* Modified the `Dial` function to use the provided `readerSize` instead of a hardcoded `ReaderSize` constant. (`lentil.go`)

### Test Updates:
* Updated test cases in `lentil_test.go` to pass the `ReaderSize` constant when calling the `Dial` function, ensuring compatibility with the new function signature. (`lentil_test.go`) [[1]](diffhunk://#diff-f183a1370fc7a9500283ac977d9b9e869bd76829fc5d26baab264ab64d71b175L11-R15) [[2]](diffhunk://#diff-f183a1370fc7a9500283ac977d9b9e869bd76829fc5d26baab264ab64d71b175L186-R186)

### Project Setup:
* Added a `go.mod` file to define the module as `github.com/nimblic/lentil` and specify Go version `1.24.1`. (`go.mod`)